### PR TITLE
changed crate name from leash to l8ash (because of name corrison)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "leash"
+name = "l8ash"
 version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 all: 
 	cargo build --release
 install:
-	strip ./target/release/leash
-	[ `id -u` = 0 ]  && install -m 755 ./target/release/leash /usr/bin/ || install -m 755 ./target/release/leash $(PREFIX)/bin/
+	strip ./target/release/l8ash
+	[ `id -u` = 0 ]  && install -m 755 ./target/release/l8ash /usr/bin/ || install -m 755 ./target/release/l8ash $(PREFIX)/bin/
 run:
 	cargo run -- -v
 test:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Optionally, leash can also check the integrity of command binaries when it is in
 # Installation
 
 ```shell
-cargo install leash
+cargo install l8ash #not `leash`!
 ```
 
 or bulid from your local source code


### PR DESCRIPTION
simply changed crate name from `leash` to `l8ash`
 